### PR TITLE
fix: Stay strictly under SQL Server's 2100-parameter limit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,9 +77,15 @@ jobs:
       uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         python-version: '${{ matrix.python-version }}'
+    - name: Install ODBC driver
+      run: |
+        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+        curl -fsSL https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+        sudo apt-get update
+        sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
     - name: Install dependencies
       run: |
-        uv sync
+        uv sync --extra pyodbc
     - name: Test with pytest
       env:
         PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,8 +79,8 @@ jobs:
         python-version: '${{ matrix.python-version }}'
     - name: Install ODBC driver
       run: |
-        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | sudo gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
-        curl -fsSL https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list
+        curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | sudo tee /usr/share/keyrings/microsoft-prod.gpg > /dev/null
+        curl -fsSL https://packages.microsoft.com/config/ubuntu/$(lsb_release -rs)/prod.list | sudo tee /etc/apt/sources.list.d/mssql-release.list > /dev/null
         sudo apt-get update
         sudo ACCEPT_EULA=Y apt-get install -y msodbcsql18
     - name: Install dependencies

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -21,6 +21,9 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
 
+_MAX_PARAM_LIMIT = 2099  # SQL Server rejects exactly 2100 parameters; keep strictly under.
+
+
 class mssqlSink(SQLSink):
     """mssql target sink class."""
 
@@ -125,8 +128,7 @@ class mssqlSink(SQLSink):
         param_marker = "?" if getattr(dialect.dbapi, "paramstyle", None) == "qmark" else "%s"
         row_placeholder = "(" + ", ".join([param_marker] * len(col_names)) + ")"
 
-        # SQL Server hard limit: 2100 parameters per statement.
-        rows_per_stmt = max(1, 2100 // len(col_names))
+        rows_per_stmt = max(1, _MAX_PARAM_LIMIT // len(col_names))
 
         total = 0
         with connection.begin():
@@ -233,7 +235,7 @@ class mssqlSink(SQLSink):
 
         param_marker = "?" if getattr(dialect.dbapi, "paramstyle", None) == "qmark" else "%s"
         row_placeholder = "(" + ", ".join([param_marker] * len(col_names)) + ")"
-        rows_per_stmt = max(1, 2100 // len(col_names))
+        rows_per_stmt = max(1, _MAX_PARAM_LIMIT // len(col_names))
 
         join_condition = " AND ".join(f"target.{quoted[k]} = source.{quoted[k]}" for k in join_keys)
         update_cols = [c for c in col_names if c not in join_keys]

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
 
-_MAX_PARAM_LIMIT = 2100  # SQL Server rejects exactly 2100 parameters; keep strictly under.
+_MAX_PARAM_LIMIT = 2099  # SQL Server rejects exactly 2100 parameters; keep strictly under.
 
 
 class mssqlSink(SQLSink):

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from sqlalchemy.engine import Connection
 
 
-_MAX_PARAM_LIMIT = 2099  # SQL Server rejects exactly 2100 parameters; keep strictly under.
+_MAX_PARAM_LIMIT = 2100  # SQL Server rejects exactly 2100 parameters; keep strictly under.
 
 
 class mssqlSink(SQLSink):

--- a/target_mssql/tests/test_core.py
+++ b/target_mssql/tests/test_core.py
@@ -267,10 +267,27 @@ def test_insert_merge(mssql_target):
     singer_file_to_target(file_name, mssql_target)
 
 
-def test_param_limit(mssql_target):
-    """Stream with 14 cols × 151 records exceeds SQL Server's 2100-parameter limit
-    unless records are chunked correctly (old formula 2100//14=150 produced exactly
-    2100 params per chunk, which SQL Server rejects)."""
+@pytest.fixture()
+def mssql_pyodbc_config():
+    return {
+        "schema": "dbo",
+        "username": "sa",
+        "password": "P@55w0rd",
+        "host": "localhost",
+        "port": "1433",
+        "database": "master",
+        "driver": "pyodbc",
+        "odbc_driver": "ODBC Driver 18 for SQL Server",
+        "trust_server_certificate": True,
+    }
+
+
+def test_param_limit(mssql_pyodbc_config):
+    """pyodbc sends true ODBC bound parameters, so SQL Server's 2100-parameter limit
+    applies. With 14 columns the old formula (2100 // 14 = 150) produced exactly 2100
+    params per chunk, which SQL Server rejects. 151 records triggers that first chunk."""
+    pytest.importorskip("pyodbc")
+
     n_cols = 13  # plus 'id' = 14 total
     n_records = 151  # one more than the old chunk size of 150
 
@@ -294,5 +311,6 @@ def test_param_limit(mssql_target):
         for i in range(n_records)
     ]
 
+    target = Targetmssql(config=mssql_pyodbc_config)
     buf = io.StringIO("\n".join(json.dumps(m) for m in [schema, *records]))
-    mssql_target.listen(buf)
+    target.listen(buf)

--- a/target_mssql/tests/test_core.py
+++ b/target_mssql/tests/test_core.py
@@ -2,6 +2,7 @@
 
 # flake8: noqa
 import io
+import json
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -264,3 +265,34 @@ def test_insert_merge(mssql_target):
 
     file_name = "insert_merge_part2.singer"
     singer_file_to_target(file_name, mssql_target)
+
+
+def test_param_limit(mssql_target):
+    """Stream with 14 cols × 151 records exceeds SQL Server's 2100-parameter limit
+    unless records are chunked correctly (old formula 2100//14=150 produced exactly
+    2100 params per chunk, which SQL Server rejects)."""
+    n_cols = 13  # plus 'id' = 14 total
+    n_records = 151  # one more than the old chunk size of 150
+
+    schema = {
+        "type": "SCHEMA",
+        "stream": "param_limit_test",
+        "schema": {
+            "properties": {
+                "id": {"type": "integer"},
+                **{f"col{i}": {"type": "integer"} for i in range(n_cols)},
+            }
+        },
+        "key_properties": ["id"],
+    }
+    records = [
+        {
+            "type": "RECORD",
+            "stream": "param_limit_test",
+            "record": {"id": i, **{f"col{j}": i * j for j in range(n_cols)}},
+        }
+        for i in range(n_records)
+    ]
+
+    buf = io.StringIO("\n".join(json.dumps(m) for m in [schema, *records]))
+    mssql_target.listen(buf)

--- a/tox.toml
+++ b/tox.toml
@@ -14,6 +14,7 @@ description = "run tests on Python {py_dot_ver}"
 dependency_groups = [
     "test"
 ]
+extras = ["pyodbc"]
 commands = [["pytest", "--capture=no"]]
 
 [env.format]


### PR DESCRIPTION
## Summary

- SQL Server rejects statements with **exactly** 2100 parameters (error 8003), not just those that exceed it
- The previous chunk formula `2100 // n_cols` could produce chunks of exactly 2100 params — e.g. a stream with 14 columns hit `150 rows × 14 = 2100` on the first chunk
- Changed to `2099 // n_cols` (extracted as `_MAX_PARAM_LIMIT = 2099`) in both `bulk_insert_records` and `merge_upsert_records`
- Added regression test: 14 columns × 151 records, which would fail against SQL Server with the old formula

## Reproducer

Stream `MaximumProgrammeDataFields` with 14 columns and batches of 8936 records. First chunk: `150 × 14 = 2100` parameters → `pyodbc.ProgrammingError: ('42000', '...The server supports a maximum of 2100 parameters...')`

## Test plan

- [ ] `uv run pytest target_mssql/tests/test_core.py::test_param_limit` passes against a live SQL Server instance