### PR TITLE
revert: Remove staging table path

### DIFF
--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -215,26 +215,13 @@ class MSSQLConnector(SQLConnector):
         # from pymssql.
         # Strip collation: MSSQL rejects quoted collation names (e.g. COLLATE "...").
         self.remove_collation(column_type)
-        # SQL Server raises error 5074 if a DEFAULT constraint is bound to the column.
-        # Drop it first so the ALTER succeeds; we don't need to recreate it.
-        table_name_str = f"{table_name}".replace("'", "''")
-        col_name_str = column_name.replace("'", "''")
         return sqlalchemy.DDL(
             """
-            DECLARE @cn NVARCHAR(256)
-            SELECT @cn = dc.name
-            FROM sys.default_constraints dc
-            JOIN sys.columns c ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
-            WHERE dc.parent_object_id = OBJECT_ID(N'%(table_name_str)s') AND c.name = N'%(col_name_str)s'
-            IF @cn IS NOT NULL
-                EXEC('ALTER TABLE %(table_name)s DROP CONSTRAINT [' + @cn + ']')
             ALTER TABLE %(table_name)s ALTER COLUMN %(column_name)s %(column_type)s
             SELECT 1 AS ok
             """,
             {
                 "table_name": table_name,
-                "table_name_str": table_name_str,
-                "col_name_str": col_name_str,
                 "column_name": self._dialect.identifier_preparer.quote(column_name),
                 "column_type": column_type,
             },

--- a/target_mssql/connector.py
+++ b/target_mssql/connector.py
@@ -215,13 +215,26 @@ class MSSQLConnector(SQLConnector):
         # from pymssql.
         # Strip collation: MSSQL rejects quoted collation names (e.g. COLLATE "...").
         self.remove_collation(column_type)
+        # SQL Server raises error 5074 if a DEFAULT constraint is bound to the column.
+        # Drop it first so the ALTER succeeds; we don't need to recreate it.
+        table_name_str = f"{table_name}".replace("'", "''")
+        col_name_str = column_name.replace("'", "''")
         return sqlalchemy.DDL(
             """
+            DECLARE @cn NVARCHAR(256)
+            SELECT @cn = dc.name
+            FROM sys.default_constraints dc
+            JOIN sys.columns c ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id
+            WHERE dc.parent_object_id = OBJECT_ID(N'%(table_name_str)s') AND c.name = N'%(col_name_str)s'
+            IF @cn IS NOT NULL
+                EXEC('ALTER TABLE %(table_name)s DROP CONSTRAINT [' + @cn + ']')
             ALTER TABLE %(table_name)s ALTER COLUMN %(column_name)s %(column_type)s
             SELECT 1 AS ok
             """,
             {
                 "table_name": table_name,
+                "table_name_str": table_name_str,
+                "col_name_str": col_name_str,
                 "column_name": self._dialect.identifier_preparer.quote(column_name),
                 "column_type": column_type,
             },

--- a/target_mssql/sinks.py
+++ b/target_mssql/sinks.py
@@ -34,10 +34,6 @@ class MSSQLSink(SQLSink[MSSQLConnector]):
 
     connector_class = MSSQLConnector
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-        self._staging_prepared = False
-
     # Copied purely to help with type hints
     @property
     def connector(self) -> MSSQLConnector:
@@ -157,12 +153,6 @@ class MSSQLSink(SQLSink[MSSQLConnector]):
             )
         return columns
 
-    @property
-    def staging_full_table_name(self) -> str:
-        """Permanent staging table for the upsert path (same schema, prefixed _staging_)."""
-        staging = f"_staging_{self.table_name}"
-        return f"{self.schema_name}.{staging}" if self.schema_name else staging
-
     def process_batch(self, context: dict) -> None:
         """Process a batch with the given batch context.
         Writes a batch to the SQL target. Developers may override this method
@@ -188,31 +178,12 @@ class MSSQLSink(SQLSink[MSSQLConnector]):
                     primary_keys=join_keys,
                     as_temp_table=False,
                 )
-
-                staging = self.staging_full_table_name
-                if not self._staging_prepared:
-                    self.connector.prepare_table(
-                        full_table_name=staging,
-                        schema=schema,
-                        primary_keys=[],
-                        as_temp_table=False,
-                    )
-                    self._staging_prepared = True
-                with connection.begin():
-                    connection.exec_driver_sql(f"TRUNCATE TABLE {staging}")  # noqa: S608
-
                 self.logger.info(f"Upserting {len(deduped_records)} records into {self.full_table_name}")
-                self.bulk_insert_records(
+                self.merge_upsert_records(
                     connection=connection,
-                    full_table_name=staging,
+                    full_table_name=self.full_table_name,
                     schema=schema,
                     records=deduped_records,
-                )
-                self.merge_upsert_from_table(
-                    connection=connection,
-                    from_table_name=staging,
-                    to_table_name=self.full_table_name,
-                    schema=schema,
                     join_keys=join_keys,
                 )
 


### PR DESCRIPTION
## Summary

- **Reverts #18 and #19** (permanent staging table upsert path): the approach caused contention/locking on the live Azure SQL database. The `TRUNCATE TABLE` + exclusive staging table locks interacted poorly with concurrent workloads. Reverted to the chunked `MERGE … USING (VALUES …)` path that bypasses tempdb directly.
- **Retains** the `merge_upsert_from_table` `matched_clause` guard added in #18 (fix for empty `UPDATE SET` when all columns are key properties).

## Test plan

- [ ] All existing tests pass (`uv run pytest`)
