### PR TITLE
fix: Suppress noisy Azure HTTP logging

### DIFF
--- a/target_mssql/azure_blob.py
+++ b/target_mssql/azure_blob.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -64,6 +65,8 @@ class AzureBlobManager:
         except ImportError:
             msg = "azure-storage-blob is required for blob staging. Install with: pip install 'target-mssql[azure]'"
             raise ImportError(msg) from None
+
+        logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(logging.WARNING)
 
         service = BlobServiceClient(account_url=self.config.account_url, credential=self.config.sas_token)
         return service.get_blob_client(container=self.config.container, blob=self.blob_name)


### PR DESCRIPTION
Suppresses logs from `azure-storage-blob` like

```console
[info ] target-mssql Request URL: 'https://***.blob.core.windows.net/***/target-mssql/6afeb9aa-0944-41d4-a824-87801dcb1e90/data.json'
[info ] target-mssql Request method: 'PUT'
[info ] target-mssql Request headers:
[info ] target-mssql 'Content-Length': '3580838'
[info ] target-mssql 'x-ms-blob-type': 'REDACTED'
[info ] target-mssql 'x-ms-version': 'REDACTED'
[info ] target-mssql 'Content-Type': 'application/octet-stream'
[info ] target-mssql 'Accept': 'application/xml'
[info ] target-mssql 'User-Agent': 'azsdk-python-storage-blob/12.30.0 Python/3.10.12 (Linux-5.15.0-1092-azure-x86_64-with-glibc2.35)'
[info ] target-mssql 'x-ms-date': 'REDACTED'
[info ] target-mssql 'x-ms-client-request-id': '399c9830-702b-11f1-bd14-5a8ec949c8e0'
[info ] target-mssql 'Authorization': 'REDACTED'
[info ] target-mssql A body is sent with the request
[info ] target-mssql Response status: 201
[info ] target-mssql Response headers:
[info ] target-mssql 'Content-Length': '0'
[info ] target-mssql 'Content-MD5': 'REDACTED'
[info ] target-mssql 'Last-Modified': 'Thu, 25 Jun 2026 00:17:17 GMT'
[info ] target-mssql 'ETag': '"0x8DED24F1DEC38D0"'
[info ] target-mssql 'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
[info ] target-mssql 'x-ms-request-id': '57c7abd9-001e-00cd-5f37-04711d000000'
[info ] target-mssql 'x-ms-client-request-id': '399c9830-702b-11f1-bd14-5a8ec949c8e0'
[info ] target-mssql 'x-ms-version': 'REDACTED'
[info ] target-mssql 'x-ms-content-crc64': 'REDACTED'
[info ] target-mssql 'x-ms-request-server-encrypted': 'REDACTED'
[info ] target-mssql 'Date': 'Thu, 25 Jun 2026 00:17:17 GMT'
[info ] target-mssql Request URL: 'https://***.blob.core.windows.net/***/target-mssql/6afeb9aa-0944-41d4-a824-87801dcb1e90/data.json'
[info ] target-mssql Request method: 'DELETE'
[info ] target-mssql Request headers:
[info ] target-mssql 'x-ms-delete-snapshots': 'REDACTED'
[info ] target-mssql 'x-ms-version': 'REDACTED'
[info ] target-mssql 'Accept': 'application/xml'
[info ] target-mssql 'User-Agent': 'azsdk-python-storage-blob/12.30.0 Python/3.10.12 (Linux-5.15.0-1092-azure-x86_64-with-glibc2.35)'
[info ] target-mssql 'x-ms-date': 'REDACTED'
[info ] target-mssql 'x-ms-client-request-id': '3a3e260a-702b-11f1-bd14-5a8ec949c8e0'
[info ] target-mssql 'Authorization': 'REDACTED'
[info ] target-mssql No body was attached to the request
[info ] target-mssql Response status: 202
[info ] target-mssql Response headers:
[info ] target-mssql 'Content-Length': '0'
[info ] target-mssql 'Server': 'Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0'
[info ] target-mssql 'x-ms-request-id': '57c7affd-001e-00cd-0937-04711d000000'
[info ] target-mssql 'x-ms-client-request-id': '3a3e260a-702b-11f1-bd14-5a8ec949c8e0'
[info ] target-mssql 'x-ms-version': 'REDACTED'
[info ] target-mssql 'x-ms-delete-type-permanent': 'REDACTED'
[info ] target-mssql 'Date': 'Thu, 25 Jun 2026 00:17:17 GMT'
```

These are emitted whenever a sink is drained - every 10000 records by default, or after 5 minutes (whichever comes first).